### PR TITLE
driver/adxl345: rename enums to avoid conflicts

### DIFF
--- a/drivers/include/adxl345.h
+++ b/drivers/include/adxl345.h
@@ -238,7 +238,6 @@ void adxl345_set_bandwidth_rate(const adxl345_t *dev, uint8_t bw_rate);
  */
 void adxl345_set_fifo_mode(const adxl345_t *dev, uint8_t mode,
                            uint8_t output, uint8_t value);
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
driver/adxl345: rename enums to avoid conflicts

https://github.com/RIOT-OS/RIOT/pull/8660#event-1497317474

force push killed the branch. 
